### PR TITLE
fix: repair the docs build and close the gap that let it break

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,15 @@ updates:
       - 'documentation'
       - 'automated'
 
+    # The docs site is pinned to Astro 2. The whole Astro ecosystem has to move
+    # together, so any isolated bump breaks the build: @astrojs/prism 4 needs
+    # Node >=22.12 and targets Astro 5, and @astrojs/mdx 0.19 calls
+    # addContentEntryType, which does not exist in Astro 2. These are held back
+    # until the site is migrated — see the tracking issue.
+    ignore:
+      - dependency-name: 'astro'
+      - dependency-name: '@astrojs/*'
+
     allow:
       - dependency-type: 'direct'
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: Wait for CI to complete
+      - name: Wait for the library build
         uses: fountainhead/action-wait-for-check@v1.2.0
         id: wait-for-ci
         with:
@@ -37,9 +37,22 @@ jobs:
           timeoutSeconds: 1800 # 30 minutes
           intervalSeconds: 30
 
+      # Both gates must be green: the library build does not cover the docs
+      # site, and a docs-only bump can break it without test-and-build noticing.
+      - name: Wait for the docs build
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: wait-for-docs
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: 'build-docs'
+          ref: ${{ github.event.pull_request.head.sha }}
+          timeoutSeconds: 1800 # 30 minutes
+          intervalSeconds: 30
+
       - name: Auto-merge minor and patch updates
         if: |
           steps.wait-for-ci.outputs.conclusion == 'success' &&
+          steps.wait-for-docs.outputs.conclusion == 'success' &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
            steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: |
@@ -52,6 +65,7 @@ jobs:
       - name: Auto-merge major GitHub Actions updates
         if: |
           steps.wait-for-ci.outputs.conclusion == 'success' &&
+          steps.wait-for-docs.outputs.conclusion == 'success' &&
           steps.metadata.outputs.update-type == 'version-update:semver-major' &&
           steps.metadata.outputs.package-ecosystem == 'github_actions'
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,10 +20,12 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v7
 
+      # Node 22: recast 0.24 declares engines.node ">= 22". Keep in sync with
+      # the build-docs job in main.yml, which gates this workflow.
       - name: Install Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install and Build 🔧
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
 
   # The docs site has its own dependency tree and was previously only built on
   # push to main, so a broken bump could not be caught before merging.
+  # Node 22: recast 0.24 declares engines.node ">= 22".
   build-docs:
     runs-on: ubuntu-latest
 
@@ -41,7 +42,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install and Build 🔧
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,4 +28,24 @@ jobs:
       - run: pnpm lint
       - run: pnpm test -- --run
       - run: pnpm build
+
+  # The docs site has its own dependency tree and was previously only built on
+  # push to main, so a broken bump could not be caught before merging.
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install and Build 🔧
+        run: |
+          cd docs
+          yarn install --frozen-lockfile
+          yarn build
   

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,8 +12,8 @@
 	},
   "packageManager": "yarn@1.22.22",
 	"dependencies": {
-		"@astrojs/mdx": "^0.19.7",
-		"@astrojs/prism": "^4.0.2",
+		"@astrojs/mdx": "^0.17.0",
+		"@astrojs/prism": "^2.0.0",
 		"@astrojs/react": "^2.0.2",
 		"@types/react": "^18.0.21",
 		"@types/react-dom": "^18.0.6",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -38,7 +38,7 @@
     vscode-languageserver-types "^3.17.1"
     vscode-uri "^3.0.3"
 
-"@astrojs/markdown-remark@^2.0.1", "@astrojs/markdown-remark@^2.2.1":
+"@astrojs/markdown-remark@^2.0.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@astrojs/markdown-remark/-/markdown-remark-2.2.1.tgz#ab063b8ae7ee526e1c3fe65b407b44fb4dee860c"
   integrity sha512-VF0HRv4GpC1XEMLnsKf6jth7JSmlt9qpqP0josQgA2eSpCIAC/Et+y94mgdBIZVBYH/yFnMoIxgKVe93xfO2GA==
@@ -57,43 +57,35 @@
     unist-util-visit "^4.1.0"
     vfile "^5.3.2"
 
-"@astrojs/mdx@^0.19.7":
-  version "0.19.7"
-  resolved "https://registry.yarnpkg.com/@astrojs/mdx/-/mdx-0.19.7.tgz#8a2ff3dc2613ef6aaff86ea039dfa76f864ecdd6"
-  integrity sha512-mfEbBD7oi8yBHhcJucEjnrquREkJ3os+jioURP8BR2B8tOV2rV2j8trvmLUgfS+P/+HevGObxCTjcRYxn6T7eg==
+"@astrojs/mdx@^0.17.0":
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/@astrojs/mdx/-/mdx-0.17.2.tgz#ad8ab05c5d61159b62df04b3ed4c912710746bb2"
+  integrity sha512-mol57cw1jJMcQgKMRGn7p6cewajq6JTNtqj5aAZgROWam/phVDSOCbXj/WU3O9+3qFnyKtpczoufQKwJTQltAw==
   dependencies:
-    "@astrojs/markdown-remark" "^2.2.1"
-    "@astrojs/prism" "^2.1.2"
+    "@astrojs/markdown-remark" "^2.0.1"
+    "@astrojs/prism" "^2.0.0"
     "@mdx-js/mdx" "^2.3.0"
+    "@mdx-js/rollup" "^2.3.0"
     acorn "^8.8.0"
     es-module-lexer "^1.1.1"
     estree-util-visit "^1.2.0"
     github-slugger "^1.4.0"
     gray-matter "^4.0.3"
-    hast-util-to-html "^8.0.4"
     kleur "^4.1.4"
     rehype-raw "^6.1.1"
     remark-frontmatter "^4.0.1"
     remark-gfm "^3.0.1"
     remark-smartypants "^2.0.0"
-    shiki "^0.14.1"
-    source-map "^0.7.4"
+    shiki "^0.11.1"
     unist-util-visit "^4.1.0"
     vfile "^5.3.2"
 
-"@astrojs/prism@^2.1.2":
+"@astrojs/prism@^2.0.0", "@astrojs/prism@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@astrojs/prism/-/prism-2.1.2.tgz#7486cb886ba3354e38ef4e58cbbe72f31337689e"
   integrity sha512-3antim1gb34689GHRQFJ88JEo93HuZKQBnmxDT5W/nxiNz1p/iRxnCTEhIbJhqMOTRbbo5h2ldm5qSxx+TMFQA==
   dependencies:
     prismjs "^1.28.0"
-
-"@astrojs/prism@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@astrojs/prism/-/prism-4.0.2.tgz#5dc0725a61ea6fe665a48474e65c968079a51f40"
-  integrity sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==
-  dependencies:
-    prismjs "^1.30.0"
 
 "@astrojs/react@^2.0.2":
   version "2.0.2"
@@ -521,7 +513,7 @@
   resolved "https://registry.yarnpkg.com/@ljharb/has-package-exports-patterns/-/has-package-exports-patterns-0.0.2.tgz#c1718939b65efa1f45f53686c2fcfa992b9fb68f"
   integrity sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw==
 
-"@mdx-js/mdx@^2.3.0":
+"@mdx-js/mdx@^2.0.0", "@mdx-js/mdx@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-2.3.0.tgz#d65d8c3c28f3f46bb0e7cb3bf7613b39980671a9"
   integrity sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==
@@ -542,6 +534,16 @@
     unist-util-position-from-estree "^1.0.0"
     unist-util-stringify-position "^3.0.0"
     unist-util-visit "^4.0.0"
+    vfile "^5.0.0"
+
+"@mdx-js/rollup@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@mdx-js/rollup/-/rollup-2.3.0.tgz#9dbdfc64e3ce4a1af041da963e1cb6f2b6450cbf"
+  integrity sha512-wLvRfJS/M4UmdqTd+WoaySEE7q4BIejYf1xAHXYvtT1du/1Tl/z2450Gg2+Hu7fh05KwRRiehiTP9Yc/Dtn0fA==
+  dependencies:
+    "@mdx-js/mdx" "^2.0.0"
+    "@rollup/pluginutils" "^5.0.0"
+    source-map "^0.7.0"
     vfile "^5.0.0"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -659,6 +661,15 @@
     picocolors "^1.0.0"
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
+
+"@rollup/pluginutils@^5.0.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.4.0.tgz#ac23a29ced0247060a210815fca39c17de4d2f26"
+  integrity sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^4.0.2"
 
 "@types/acorn@^4.0.0":
   version "4.0.6"
@@ -1433,6 +1444,11 @@ estree-util-visit@^1.0.0, estree-util-visit@^1.2.0:
     "@types/estree-jsx" "^1.0.0"
     "@types/unist" "^2.0.0"
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 estree-walker@^3.0.0, estree-walker@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
@@ -1767,7 +1783,7 @@ hast-util-to-estree@^2.0.0:
     unist-util-position "^4.0.0"
     zwitch "^2.0.0"
 
-hast-util-to-html@^8.0.0, hast-util-to-html@^8.0.4:
+hast-util-to-html@^8.0.0:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz#0269ef33fa3f6599b260a8dc94f733b8e39e41fc"
   integrity sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==
@@ -2946,7 +2962,7 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.4:
+picomatch@^4.0.2, picomatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
@@ -3029,7 +3045,7 @@ prism-react-renderer@^1.3.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz#786bb69aa6f73c32ba1ee813fbe17a0115435085"
   integrity sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==
 
-prismjs@^1.28.0, prismjs@^1.30.0:
+prismjs@^1.28.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
@@ -3388,7 +3404,7 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-source-map@^0.7.0, source-map@^0.7.3, source-map@^0.7.4:
+source-map@^0.7.0, source-map@^0.7.3:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==


### PR DESCRIPTION
## What broke

The **Build and Deploy docs** workflow has been failing on `main` since `b9284c1`. Seven consecutive runs have failed; the last green one was `1b9798a`.

Two Astro-ecosystem bumps are incompatible with the docs site, which is pinned to `astro@^2.0.14`:

| Package | Bump | Failure |
|---|---|---|
| `@astrojs/prism` | 2.0.0 → 4.0.2 | Requires Node `>=22.12.0` (the workflow runs Node 20), and targets Astro 5 |
| `@astrojs/mdx` | 0.17.2 → 0.19.7 | Calls `addContentEntryType`, which does not exist in Astro 2 — `astro build` fails even once the engine check passes |

Raising the Node version is **not** sufficient: with Node 22 the install succeeds and the build still dies on `addContentEntryType is not a function`. Both were verified locally.

`copy-to-clipboard` 4.0.2 is not implicated and is kept.

## Why it reached main

The pre-merge gate did not cover the docs site.

- `test-and-build` runs `on: pull_request`, but only lints, tests and builds **the library**
- the docs site was only ever built by `deploy-docs.yml`, which runs `on: push` to `main`

A docs-only bump could therefore pass every PR check, merge green, and break `main` immediately afterwards. The failure was structurally invisible before merge.

## What this changes

1. **Fix** — `@astrojs/prism` back to `^2.0.0`, `@astrojs/mdx` back to `^0.17.0`, `docs/yarn.lock` regenerated. `yarn build` verified locally (`1 page(s) built`, `Complete!`).
2. **Close the gap** — new `build-docs` job in `main.yml`, so the docs site is built on every PR rather than only after merge.
3. **Both gates required** — the Dependabot auto-merge workflow now waits on `build-docs` as well as `test-and-build`; neither alone can approve a merge.
4. **Prevent recurrence** — `astro` and `@astrojs/*` are held back in `dependabot.yml`. Ignoring majors alone would not be enough: the `@astrojs/mdx` break was a `0.x` **minor**.

## Follow-up

Holding the Astro ecosystem back is a stopgap, not a fix — the site stays on Astro 2 and stops receiving updates entirely. Migrating it is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)