### PR TITLE
fix: stop reading refs during render and syncing props via an effect

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,13 +42,6 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       'no-constant-binary-expression': 'off',
       'react/no-unused-prop-types': 'error',
-      // eslint-plugin-react-hooks 7 adds two React Compiler-era rules that
-      // flag real patterns in Tabs.tsx: refs read during render inside
-      // getChildren(), and the selected-prop-to-state sync effect. Both are
-      // legitimate, but fixing them means restructuring the component, so
-      // they stay visible as warnings until that is done deliberately.
-      'react-hooks/refs': 'warn',
-      'react-hooks/set-state-in-effect': 'warn',
     },
   },
 )

--- a/src/TabPanel.tsx
+++ b/src/TabPanel.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import type { FunctionComponent, HTMLAttributes } from 'react'
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { useState } from 'react'
 
 export type TabPanelProps = {
   active?: boolean
@@ -21,13 +21,15 @@ const TabPanel: FunctionComponent<TabPanelProps> = ({
   disabled,
   ...divProps
 }) => {
-  const hasBeenActive = useRef(active)
+  // State rather than a ref: this value is read during render to decide
+  // whether children stay mounted, which a ref cannot safely provide.
+  // Adjusting it during render lets React re-run the component immediately,
+  // where a layout effect would only apply it on the following pass.
+  const [hasBeenActive, setHasBeenActive] = useState(active)
 
-  useLayoutEffect(() => {
-    if (!hasBeenActive.current && active) {
-      hasBeenActive.current = true
-    }
-  }, [active])
+  if (active && !hasBeenActive) {
+    setHasBeenActive(true)
+  }
 
   return (
     <div
@@ -39,7 +41,7 @@ const TabPanel: FunctionComponent<TabPanelProps> = ({
       style={!active ? { display: 'none' } : undefined}
       {...divProps}
     >
-      {(active || hasBeenActive.current) && children}
+      {(active || hasBeenActive) && children}
     </div>
   )
 }

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import React, { useCallback, useId, useMemo, useRef, useState } from 'react'
 import { getTabProps } from './helpers/childrenUtils'
 import {
   isTabElement,
@@ -52,25 +45,32 @@ const Tabs = ({
   const id = useId()
   const tabProps = useMemo(() => getTabProps(children), [children])
   const tabNames = useMemo(() => tabProps.map((tab) => tab.name), [tabProps])
-  const tabIds = useRef(tabProps.map((_, i) => `${id}-${i}`))
+  // Derived, not a ref: reading and growing a ref during render is unsafe
+  // under concurrent rendering. The ids are a pure function of the tab list.
+  const tabIds = useMemo(
+    () => tabNames.map((_, i) => `${id}-${i}`),
+    [id, tabNames],
+  )
   const tabRefs = useRef<HTMLLIElement[]>([])
   const currentFocusIndex = useRef(
     (typeof selected === 'string' ? tabNames.indexOf(selected) : selected) ?? 0,
   )
   const [{ index: currentIndex, name: currentName }, setSelected] = useState(
-    computeState(tabNames, selected),
+    () => computeState(tabNames, selected),
   )
 
-  useEffect(() => {
+  // Compared as a string so that a children update producing an equal tab list
+  // does not reset the selected tab.
+  const tabNamesKey = tabNames.join(',')
+  const [previous, setPrevious] = useState({ selected, tabNamesKey })
+
+  // Adjusting state during render is React's documented alternative to
+  // synchronising props into state from an effect: React re-runs the component
+  // immediately, without committing the intermediate result or painting it.
+  if (previous.selected !== selected || previous.tabNamesKey !== tabNamesKey) {
+    setPrevious({ selected, tabNamesKey })
     setSelected(computeState(tabNames, selected))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    selected,
-    // Hack: use deep equal to compare to previous tabNames,
-    // so that children update don't lead to a reset of the selected tab.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    tabNames.join(','),
-  ])
+  }
 
   const handleSelect = useCallback(
     (index: number, name?: string) => {
@@ -120,16 +120,6 @@ const Tabs = ({
   const getChildren = useCallback(() => {
     let tabPanelIndex = 0
 
-    const idsToCreate = tabNames.length - tabIds.current.length
-
-    if (idsToCreate > 0) {
-      tabIds.current.push(
-        ...Array.from(new Array(idsToCreate)).map(
-          (_, index) => `${id}-${tabNames.length + index - 1}`,
-        ),
-      )
-    }
-
     return React.Children.map(children, (child) => {
       if (isTabListElement(child)) {
         return React.cloneElement(child, {
@@ -144,8 +134,8 @@ const Tabs = ({
                   ...tab.props,
                   autoFocus: focusOnInit && index === currentIndex,
                   active: index === currentIndex,
-                  'aria-controls': `${tabIds.current[index]}-panel`,
-                  id: `${tabIds.current[index]}-tab`,
+                  'aria-controls': `${tabIds[index]}-panel`,
+                  id: `${tabIds[index]}-tab`,
                   onClick: () => handleSelect(index, tab.props.name),
                   onKeyDown: autoActivate
                     ? undefined
@@ -180,11 +170,11 @@ const Tabs = ({
           ...child.props,
           active: panelIndex === currentIndex,
           disabled: tabProps[panelIndex]?.disabled,
-          id: tabIds.current[panelIndex]
-            ? `${tabIds.current[panelIndex]}-panel`
+          id: tabIds[panelIndex]
+            ? `${tabIds[panelIndex]}-panel`
             : undefined,
-          'aria-labelledby': tabIds.current[panelIndex]
-            ? `${tabIds.current[panelIndex]}-tab`
+          'aria-labelledby': tabIds[panelIndex]
+            ? `${tabIds[panelIndex]}-tab`
             : undefined,
         })
 
@@ -208,10 +198,9 @@ const Tabs = ({
     currentIndex,
     focusOnInit,
     handleSelect,
-    id,
     selectNext,
     selectPrevious,
-    tabNames.length,
+    tabIds,
     tabProps,
   ])
 


### PR DESCRIPTION
Closes #115. Both `react-hooks` rules added by eslint-plugin-react-hooks 7 are raised back to **`error`**, and the lint run is clean with them enforced.

## A correction to the issue

#115 attributed all three findings to `Tabs.tsx`. Two of them were actually in `TabPanel.tsx` — worth stating, because it changes what had to be touched.

## `Tabs.tsx` — tab ids were a ref read and mutated during render

`getChildren()` both read `tabIds.current` and pushed to it, during render. The ids are a pure function of the tab list, so they are now derived:

```diff
-const tabIds = useRef(tabProps.map((_, i) => `${id}-${i}`))
+const tabIds = useMemo(() => tabNames.map((_, i) => `${id}-${i}`), [id, tabNames])
```

The growth branch disappears with it. The memo already produces one id per tab, where the ref only appended when the list got longer and never shrank.

## `Tabs.tsx` — prop synced into state via an effect

Replaced by adjusting state during render, React's documented alternative. Previous values are tracked in state and compared:

```tsx
const tabNamesKey = tabNames.join(',')
const [previous, setPrevious] = useState({ selected, tabNamesKey })

if (previous.selected !== selected || previous.tabNamesKey !== tabNamesKey) {
  setPrevious({ selected, tabNamesKey })
  setSelected(computeState(tabNames, selected))
}
```

The behaviour the old `// Hack:` comment protected is preserved, and now stated in code rather than in a dependency-array comment: the tab list is still compared as a joined string, so a children update yielding an equal list does not reset the selected tab.

## `TabPanel.tsx` — ref read during render to keep children mounted

```diff
-const hasBeenActive = useRef(active)
-useLayoutEffect(() => {
-  if (!hasBeenActive.current && active) hasBeenActive.current = true
-}, [active])
+const [hasBeenActive, setHasBeenActive] = useState(active)
+if (active && !hasBeenActive) setHasBeenActive(true)
```

This was exactly what a ref cannot safely do — a value read during render to decide output. The `useLayoutEffect` that maintained it is no longer needed.

The old code also applied the flag **one pass late**: on the render where `active` first became true, `hasBeenActive.current` was still `false`. That was invisible only because `active` was true on that same render, so the `||` covered it. The new version is correct on the render itself.

## Verification

- `pnpm lint` — exit 0, **zero warnings**, both rules at `error` (confirmed via `eslint --print-config`)
- `pnpm test` — 68 tests passing, **unmodified**
- `pnpm build` — green

No public API change: `TabsProps` is untouched, and `selected` still accepts an index or a name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)