### PR TITLE
ci: hold back the ESLint and TypeScript majors that are blocked upstream

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,16 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@types/react-dom'
         update-types: ['version-update:semver-major']
+      # ESLint 10 and TypeScript 7 are blocked by the plugin ecosystem, not by
+      # anything in this repo — see the tracking issues. Only majors are held
+      # back, so 9.x and 5.x fixes still come through. Remove these entries
+      # when the blocks lift; the issues say what to watch for.
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
     allow:
       - dependency-type: 'direct'


### PR DESCRIPTION
## Context

ESLint 10 (#119) and TypeScript 7 (#120) cannot be adopted. Both were attempted and both fail for reasons outside this repository:

- `eslint-plugin-react` calls `context.getFilename()`, removed in ESLint 10 — lint dies with a `TypeError`
- `typescript-eslint` throws an explicit `does not support TS 7.0` guard

Neither is fixable here. Dependabot will nonetheless keep proposing them.

## Reversing what I wrote in #119

#119 argued **against** adding ignore rules, on the grounds that a passing PR would be the signal the block had lifted. That reasoning was wrong about the cost.

The npm ecosystem has `open-pull-requests-limit: 5`. Two permanently-red PRs would occupy **40% of the available slots indefinitely**, starving every other update — the same saturation that stalled `/docs` at 3/3 yesterday and stopped new docs PRs from appearing at all.

The signal is worth less than the throughput, especially since checking the block by hand is two `npm view` calls.

## Scope

Only **majors** are held back:

```yaml
- dependency-name: 'eslint'
  update-types: ['version-update:semver-major']
- dependency-name: '@eslint/js'
  update-types: ['version-update:semver-major']
- dependency-name: 'typescript'
  update-types: ['version-update:semver-major']
```

9.x and 5.x fixes still come through, including security ones.

## How the blocks get rechecked

By hand, which the issues describe precisely enough to make routine:

- **#119** — watch `eslint-plugin-react`'s declared `peerDependencies.eslint` range for `^10`
- **#120** — watch `typescript-eslint`'s declared `peerDependencies.typescript` range for `>=7`

Both issues also record the migration work already done and validated, so neither has to be rediscovered — #120 in particular carries the two `tsconfig` edits TS 7 needs, verified to produce a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)