### PR TITLE
test: add a Playwright e2e pipeline for release and source changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,14 @@
 name: E2E
 
 # The Playwright suite drives the Ladle stories in three real browsers, which is
-# far slower than the unit tests. It therefore runs only on release pull
-# requests — the last gate before a version is published to npm — instead of on
-# every pull request.
+# far slower than the unit tests, so it does not run on every pull request. It
+# runs on the two kinds of pull request where it earns its cost: release ones,
+# the last gate before a version is published to npm, and any that touch the
+# library source or the suite itself. The `gate` job below decides.
+#
+# The decision cannot live in an `on.paths` filter: a release pull request only
+# changes CHANGELOG.md and package.json, so a path filter would keep the
+# workflow from triggering there at all.
 on:
   pull_request:
     branches:
@@ -16,14 +21,79 @@ permissions:
   contents: read
 
 jobs:
+  gate:
+    name: Decide whether to run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: read # to list the files the pull request touches
+
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+
+    steps:
+      - name: Decide
+        id: decide
+        env:
+          # Everything from the event goes through the environment: interpolating
+          # a branch name straight into a shell script is a script injection.
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          decide() {
+            echo "run=$1" >> "$GITHUB_OUTPUT"
+            echo "Running the suite: $1 — $2" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          # Manual dispatch always runs.
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            decide true 'manual dispatch'
+          fi
+
+          # release-please opens its release pull request from a
+          # `release-please--*` branch and labels it `autorelease: pending`.
+          # Either marker is enough, so a hand-made release pull request
+          # carrying the label is covered too.
+          case "$HEAD_REF" in
+            release-please--*) decide true "release branch $HEAD_REF" ;;
+          esac
+
+          if printf '%s' "$LABELS" | grep -qF 'autorelease: pending'; then
+            decide true 'the autorelease: pending label'
+          fi
+
+          # Otherwise: only when the change can actually affect the suite —
+          # the library source or the suite itself. Unit tests and stories are
+          # excluded: they ship nothing.
+          # Listed in its own step so a failing API call fails the job, instead
+          # of being read as "nothing relevant changed".
+          files=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
+
+          changed=$(
+            printf '%s\n' "$files" \
+              | grep -E '^(src/|e2e/|playwright\.config\.ts$)' \
+              | grep -Ev '^src/(__tests__|__stories__)/' \
+              || true
+          )
+
+          if [ -n "$changed" ]; then
+            decide true "$(printf 'changed files:\n%s' "$changed")"
+          fi
+
+          decide false 'no release marker, and no change under src/ or e2e/'
+
   e2e:
-    # release-please opens its release PR from a `release-please--branches--*`
-    # branch and labels it `autorelease: pending`. Either marker is enough, so a
-    # manually created release PR carrying the label is covered too.
-    if: |
-      github.event_name == 'workflow_dispatch'
-      || startsWith(github.head_ref, 'release-please--')
-      || contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
 
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,58 @@
+name: E2E
+
+# The Playwright suite drives the Ladle stories in three real browsers, which is
+# far slower than the unit tests. It therefore runs only on release pull
+# requests — the last gate before a version is published to npm — instead of on
+# every pull request.
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize, labeled]
+  # Manual escape hatch, to run the suite on demand from any branch.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    # release-please opens its release PR from a `release-please--branches--*`
+    # branch and labels it `autorelease: pending`. Either marker is enough, so a
+    # manually created release PR carrying the label is covered too.
+    if: |
+      github.event_name == 'workflow_dispatch'
+      || startsWith(github.head_ref, 'release-please--')
+      || contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: |
+            - recursive: false
+              args: [--frozen-lockfile, --prefer-offline]
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium firefox webkit
+
+      - name: Run the e2e tests 🧪
+        run: pnpm test:e2e
+
+      - name: Upload the Playwright report 📊
+        uses: actions/upload-artifact@v5
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 dist/
 
+# Playwright
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/
+
 # Logs
 logs
 *.log

--- a/e2e/fixtures/story.ts
+++ b/e2e/fixtures/story.ts
@@ -1,0 +1,19 @@
+import { expect, type Page } from '@playwright/test'
+
+/** Ladle story ids, as exposed by http://127.0.0.1:61000/meta.json */
+export type StoryId =
+  | 'tabs--default'
+  | 'tabs--lazy-loading'
+  | 'tabs--styled-components'
+  | 'tabs--auto-activation-disabled'
+  | 'tabs--hidden-tab'
+  | 'tabs--empty-tabs'
+
+/**
+ * Opens a story in Ladle's preview mode (no sidebar, no addon toolbar), so the
+ * page contains nothing but the component under test.
+ */
+export async function gotoStory(page: Page, story: StoryId) {
+  await page.goto(`/?story=${story}&mode=preview`)
+  await expect(page.getByRole('tablist')).toBeAttached()
+}

--- a/e2e/keyboard-navigation.spec.ts
+++ b/e2e/keyboard-navigation.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test'
+import { gotoStory } from './fixtures/story'
+
+test.describe('Keyboard navigation with auto activation', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoStory(page, 'tabs--default')
+    await page.getByRole('tab', { name: 'Tab 1' }).focus()
+  })
+
+  test('ArrowRight skips the disabled tabs', async ({ page }) => {
+    // Tab 2 and Tab 3 are disabled in the story, so Tab 1 → Tab 4.
+    await page.keyboard.press('ArrowRight')
+
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 3')).toBeVisible()
+
+    await page.keyboard.press('ArrowRight')
+
+    await expect(page.getByRole('tab', { name: 'Tab 5' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+  })
+
+  test('ArrowLeft wraps around to the last tab', async ({ page }) => {
+    await page.keyboard.press('ArrowLeft')
+
+    await expect(page.getByRole('tab', { name: 'Tab 5' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 4')).toBeVisible()
+  })
+
+  test('ArrowRight wraps around to the first tab', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Tab 5' }).click()
+    await page.keyboard.press('ArrowRight')
+
+    await expect(page.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 0')).toBeVisible()
+  })
+
+  test('only the selected tab is reachable with Tab', async ({ page }) => {
+    // Roving tabindex: the selected tab holds tabindex=0, the others -1.
+    await expect(page.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'tabindex',
+      '0',
+    )
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveAttribute(
+      'tabindex',
+      '-1',
+    )
+  })
+})
+
+test.describe('Keyboard navigation without auto activation', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoStory(page, 'tabs--auto-activation-disabled')
+    await page.getByRole('tab', { name: 'Tab 1' }).focus()
+  })
+
+  test('arrow keys move the focus without changing the selection', async ({
+    page,
+  }) => {
+    await page.keyboard.press('ArrowRight')
+
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toBeFocused()
+    await expect(page.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 0')).toBeVisible()
+  })
+
+  test('Enter activates the focused tab', async ({ page }) => {
+    await page.keyboard.press('ArrowRight')
+    await page.keyboard.press('Enter')
+
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByRole('tabpanel')).toHaveText('Tab 4 content')
+    await expect(page.getByText('Selected index: 3')).toBeVisible()
+  })
+
+  test('Space activates the focused tab', async ({ page }) => {
+    await page.keyboard.press('ArrowLeft')
+    await page.keyboard.press(' ')
+
+    await expect(page.getByRole('tab', { name: 'Tab 5' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 4')).toBeVisible()
+  })
+})

--- a/e2e/lazy-loading.spec.ts
+++ b/e2e/lazy-loading.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+import { gotoStory } from './fixtures/story'
+
+test.describe('Lazy panel content', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoStory(page, 'tabs--lazy-loading')
+  })
+
+  test('does not render the content of a never activated panel', async ({
+    page,
+  }) => {
+    const panels = page.getByRole('tabpanel', { includeHidden: true })
+
+    await expect(panels).toHaveCount(2)
+    await expect(panels.nth(0)).toHaveText('Content 1')
+    await expect(panels.nth(1)).toBeEmpty()
+  })
+
+  test('renders the content once the panel becomes active', async ({
+    page,
+  }) => {
+    await page.getByRole('tab', { name: 'Async' }).click()
+
+    // The story resolves its async content after 5s; before that the panel
+    // shows its own loading state.
+    await expect(page.getByRole('tabpanel')).toHaveText(
+      /Loading\.\.\.|Async content loaded/,
+    )
+    await expect(page.getByRole('tabpanel').locator('b')).toHaveText(
+      'Async content loaded',
+      { timeout: 15_000 },
+    )
+  })
+
+  test('keeps the content mounted after switching away and back', async ({
+    page,
+  }) => {
+    await page.getByRole('tab', { name: 'Async' }).click()
+    await expect(page.getByRole('tabpanel').locator('b')).toBeVisible({
+      timeout: 15_000,
+    })
+
+    await page.getByRole('tab', { name: 'Tab 1' }).click()
+    await expect(page.getByRole('tabpanel')).toHaveText('Content 1')
+
+    // The panel keeps its rendered content while hidden.
+    await expect(
+      page.getByRole('tabpanel', { includeHidden: true }).nth(1),
+    ).toHaveText('Async content loaded')
+
+    await page.getByRole('tab', { name: 'Async' }).click()
+    await expect(page.getByRole('tabpanel')).toHaveText('Async content loaded')
+  })
+})

--- a/e2e/tabs.spec.ts
+++ b/e2e/tabs.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test'
+import { gotoStory } from './fixtures/story'
+
+test.describe('Tabs', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoStory(page, 'tabs--default')
+  })
+
+  test('selects the first tab on load', async ({ page }) => {
+    await expect(page.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByRole('tabpanel')).toHaveText('Tab 1 content')
+    await expect(page.getByText('Selected index: 0')).toBeVisible()
+  })
+
+  test('selects a tab on click and shows its panel', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Tab 4' }).click()
+
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+    await expect(page.getByRole('tabpanel')).toHaveText('Tab 4 content')
+    await expect(page.getByText('Selected index: 3')).toBeVisible()
+  })
+
+  test('ignores clicks on a disabled tab', async ({ page }) => {
+    const disabledTab = page.getByRole('tab', { name: 'Tab 2' })
+    await expect(disabledTab).toHaveAttribute('aria-disabled', 'true')
+
+    // force: Playwright would otherwise refuse to click an aria-disabled
+    // element, and dispatching the click is the whole point of this test.
+    await disabledTab.click({ force: true })
+
+    await expect(disabledTab).toHaveAttribute('aria-selected', 'false')
+    await expect(page.getByText('Selected index: 0')).toBeVisible()
+  })
+
+  test('links each tab to its panel with aria attributes', async ({ page }) => {
+    const tab = page.getByRole('tab', { name: 'Tab 4' })
+    await tab.click()
+
+    const tabId = await tab.getAttribute('id')
+    const panel = page.getByRole('tabpanel')
+
+    await expect(panel).toHaveAttribute('aria-labelledby', `${tabId}`)
+    await expect(tab).toHaveAttribute(
+      'aria-controls',
+      `${await panel.getAttribute('id')}`,
+    )
+  })
+
+  test('keeps the selected tab when a tab is added', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Tab 4' }).click()
+    await page.getByRole('button', { name: 'Add' }).click()
+
+    await expect(page.getByRole('tab')).toHaveCount(6)
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 3')).toBeVisible()
+  })
+
+  test('drives the selection from the Prev and Next buttons', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Next' }).click()
+    await expect(page.getByText('Selected index: 1')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Prev' }).click()
+    await expect(page.getByText('Selected index: 0')).toBeVisible()
+  })
+})
+
+test.describe('Tabs with a hidden tab', () => {
+  test('ignores falsy children when pairing tabs and panels', async ({
+    page,
+  }) => {
+    await gotoStory(page, 'tabs--hidden-tab')
+
+    await expect(page.getByRole('tab')).toHaveCount(2)
+    await expect(page.getByRole('tab', { name: 'tab 2' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByRole('tabpanel')).toHaveText('content 2')
+
+    await page.getByRole('tab', { name: 'tab 3' }).click()
+    await expect(page.getByRole('tabpanel')).toHaveText('content 3')
+  })
+})
+
+test.describe('Tabs styled with styled-components', () => {
+  test('applies the active and disabled styles to the real DOM', async ({
+    page,
+  }) => {
+    await gotoStory(page, 'tabs--styled-components')
+
+    // The story styles the active tab #235a8e, an idle tab #003465 and a
+    // disabled tab #ccc — only a real browser can confirm the cascade.
+    await expect(page.getByRole('tab', { name: 'Tab 1' })).toHaveCSS(
+      'background-color',
+      'rgb(35, 90, 142)',
+    )
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveCSS(
+      'background-color',
+      'rgb(0, 52, 101)',
+    )
+    await expect(page.getByRole('tab', { name: 'Tab 2' })).toHaveCSS(
+      'background-color',
+      'rgb(204, 204, 204)',
+    )
+
+    await page.getByRole('tab', { name: 'Tab 4' }).click()
+
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveCSS(
+      'background-color',
+      'rgb(35, 90, 142)',
+    )
+  })
+})

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "build:js": "tsc -p tsconfig.build.json && vite build",
     "build": "pnpm run build:js && pnpm run build:dts",
     "lint": "eslint .",
+    "stories:build": "ladle build --viteConfig vite.ladle.config.ts",
+    "stories:preview": "ladle preview -h 127.0.0.1 -p 61000",
     "test": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"
   },
   "keywords": [
@@ -32,6 +36,7 @@
     "@commitlint/config-conventional": "^21.2.2",
     "@eslint/js": "^9.9.0",
     "@ladle/react": "^5.1.1",
+    "@playwright/test": "^1.62.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// The e2e suite drives the real components through the Ladle stories in
+// src/__stories__, so it covers what jsdom-based unit tests cannot: focus
+// management, real key events and the browsers we claim to support.
+const PORT = 61000
+const BASE_URL = `http://127.0.0.1:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+
+  // The suite runs against the built stories rather than `ladle serve`: the
+  // static build is deterministic, and the dev server needs the docs/ workspace
+  // dependencies installed to boot.
+  webServer: {
+    command: 'pnpm run stories:build && pnpm run stories:preview',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,8 +26,9 @@ export default defineConfig({
   ],
 
   // The suite runs against the built stories rather than `ladle serve`: the
-  // static build is deterministic, and the dev server needs the docs/ workspace
-  // dependencies installed to boot.
+  // static build is deterministic, and the dev server currently serves nothing
+  // but 404s — @vitejs/plugin-react 6 cannot run inside the Vite 6 that Ladle
+  // pins, see issue #125.
   webServer: {
     command: 'pnpm run stories:build && pnpm run stories:preview',
     url: BASE_URL,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@ladle/react':
         specifier: ^5.1.1
         version: 5.1.1(@types/node@26.2.0)(@types/react@19.2.18)(jiti@2.6.1)(lightningcss@1.33.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.102.0)(typescript@5.9.3)
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1
@@ -712,6 +715,11 @@ packages:
   '@parcel/watcher@2.6.0':
     resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.2.4':
     resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
@@ -2172,6 +2180,11 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3116,6 +3129,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4582,6 +4605,10 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.6.0
       '@parcel/watcher-win32-x64': 2.6.0
     optional: true
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.2.4':
     optional: true
@@ -6070,6 +6097,9 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7372,6 +7402,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,25 @@ CustomTab.displayName = 'Tab'
  - Keyboard navigation
  - Auto activation
 
+## Testing
+
+Unit tests run on every pull request:
+
+```sh
+pnpm test          # watch mode
+pnpm test -- --run # single run
+```
+
+End-to-end tests drive the Ladle stories with Playwright in Chromium, Firefox and WebKit. They cover what jsdom cannot: focus management, real key events and cross-browser styling.
+
+```sh
+pnpm exec playwright install # once, to download the browsers
+pnpm test:e2e                # builds the stories, serves them, runs the suite
+pnpm test:e2e:ui             # same, in Playwright's UI mode
+```
+
+In CI, the e2e suite only runs on release pull requests — the ones opened by release-please — and can be triggered manually from the Actions tab (`E2E` workflow).
+
 ## Roadmap
   
   - [ ] Documentation site

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,11 @@ pnpm test:e2e                # builds the stories, serves them, runs the suite
 pnpm test:e2e:ui             # same, in Playwright's UI mode
 ```
 
-In CI, the e2e suite only runs on release pull requests — the ones opened by release-please — and can be triggered manually from the Actions tab (`E2E` workflow).
+In CI, the e2e suite does not run on every pull request. It runs on:
+
+ - release pull requests — the ones opened by release-please, or any pull request labelled `autorelease: pending`;
+ - pull requests touching the library source (`src/`, except `__tests__` and `__stories__`) or the suite itself (`e2e/`, `playwright.config.ts`);
+ - manual runs, from the Actions tab (`E2E` workflow).
 
 ## Roadmap
   

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: './setupTests.ts',
+    // e2e/ holds Playwright specs, which must not be picked up by Vitest.
+    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**'],
     coverage: {
       exclude: ['setupTests.ts', '**/*.test.tsx', '**/*.stories.tsx'],
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Why

The unit tests run in happy-dom, so a whole class of behaviour is out of reach: focus management, real key events, and the CSS cascade (styled-components). This adds an end-to-end suite that drives the Ladle stories in **Chromium, Firefox and WebKit**.

Three real browsers on every pull request would be needlessly slow, so the suite runs on the two kinds of pull request where it earns its cost: **release** ones (the last gate before a version is published to npm) and any that **touch the library source or the suite itself** — plus on manual dispatch.

## What

**`.github/workflows/e2e.yml`** — new `E2E` workflow, triggered on `pull_request` targeting `main`. A cheap `gate` job decides whether the suite runs, and the `e2e` job `needs` it. It runs when:

- the head branch starts with `release-please--`, **or**
- the PR carries the `autorelease: pending` label (covers a hand-made release PR), **or**
- the PR touches `src/**` (excluding `src/__tests__/**` and `src/__stories__/**`, which ship nothing), `e2e/**` or `playwright.config.ts`, **or**
- it is a `workflow_dispatch`.

The path check cannot be an `on.paths` filter: a release PR only changes `CHANGELOG.md` and `package.json`, so a path filter would stop the workflow from triggering there at all. The gate therefore lists the PR's files through the API — with everything from the event passed through the environment, never interpolated into the shell.

It installs the three browsers, runs `pnpm test:e2e`, and uploads the HTML report as an artifact. `main.yml` (lint / unit / build) is unchanged and still runs on every PR.

**`playwright.config.ts`** — three browser projects, `retries: 2` and the `github` + `html` reporters in CI, `trace: on-first-retry`.

**`e2e/`** — 18 tests against the existing stories (`?story=…&mode=preview`):

- `tabs.spec.ts` — selection on click, `aria-controls` / `aria-labelledby` pairing, clicks ignored on a disabled tab, dynamically added tab, `Prev` / `Next` buttons, hidden tabs, and the real computed styles with styled-components (`toHaveCSS`).
- `keyboard-navigation.spec.ts` — `ArrowRight` / `ArrowLeft` skipping disabled tabs, wrap-around, roving tabindex, and the `autoActivate={false}` mode (focus moves without selecting, then `Enter` / `Space` activates).
- `lazy-loading.spec.ts` — a never-activated panel renders no content, async content appears once activated, content stays mounted across a round trip.

## Note on the web server

The suite runs against the **built** stories (`stories:build` + `stories:preview`) rather than `ladle serve`. The dev server currently serves nothing but 404s in this repo: `@vitejs/plugin-react` 6 (the root devDependency, required by the Vite 8 library build) runs its react-refresh transform through a rolldown builtin plugin, which the Vite 6 that Ladle 5.1.1 pins rejects with `Missing field moduleType`. Diagnosed and tracked in #125 — the wrapper is dev-only, so `ladle build` is unaffected. The static build is also more deterministic in CI.

Note that `ladle build` writes to `build/` at the root, which is already gitignored.

Also included: the `test:e2e` / `test:e2e:ui` / `stories:*` scripts, `e2e/**` excluded from Vitest (otherwise `pnpm test` would pick up the Playwright specs), and the Playwright report folders added to `.gitignore`.

## Verification

- `npx playwright test` — **54 tests passing** (18 × 3 browsers), including a cold run with `CI=1` where Playwright starts the server itself.
- `pnpm test -- --run` — 68 unit tests across 5 files; the e2e specs are correctly excluded.
- `pnpm lint` — no errors (the 4 warnings are pre-existing in `Tabs.tsx`).

The gate logic was replayed locally against every open PR before being committed:

| PR | Head branch / content | Decision |
| --- | --- | --- |
| #124 (this one) | `e2e/**`, `playwright.config.ts` | **run** |
| #123 | `.github/dependabot.yml` only | skip |
| #122 | `src/Tabs.tsx`, `src/TabPanel.tsx` | **run** |
| #118 | `release-please--branches--main--…` | **run** |
| — | `workflow_dispatch` | **run** |

The suite also ran green once on this PR through the `autorelease: pending` marker (54/54, 1.4 min) before the gate existed, and now runs on it for real via the source-change path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
