### PR TITLE
fix: unbreak the Ladle dev server by dropping the root react plugin

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,16 +71,17 @@ jobs:
             decide true 'the autorelease: pending label'
           fi
 
-          # Otherwise: only when the change can actually affect the suite —
-          # the library source or the suite itself. Unit tests and stories are
-          # excluded: they ship nothing.
-          # Listed in its own step so a failing API call fails the job, instead
-          # of being read as "nothing relevant changed".
+          # Otherwise: only when the change can actually affect the suite — the
+          # library source, the suite itself, or the config that builds the
+          # stories the suite drives. Unit tests and stories are excluded: they
+          # ship nothing.
+          # Listed in its own variable so a failing API call fails the job,
+          # instead of being read as "nothing relevant changed".
           files=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
 
           changed=$(
             printf '%s\n' "$files" \
-              | grep -E '^(src/|e2e/|playwright\.config\.ts$)' \
+              | grep -E '^(src/|e2e/|(playwright\.config|vite\.ladle\.config)\.ts$)' \
               | grep -Ev '^src/(__tests__|__stories__)/' \
               || true
           )

--- a/vite.ladle.config.ts
+++ b/vite.ladle.config.ts
@@ -1,12 +1,16 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
+//
+// No react() plugin here on purpose: Ladle injects its own @vitejs/plugin-react,
+// pinned to the Vite major it runs. Adding the root one — version 6, which the
+// Vite 8 library build needs — makes the dev server transform every module
+// through a rolldown builtin that Ladle's Vite 6 rejects with
+// `Missing field moduleType`, and nothing gets served. See issue #125.
 export default defineConfig({
   build: {
     sourcemap: true,
   },
-  plugins: [react()],
   server: {
     host: '0.0.0.0',
     hmr: {


### PR DESCRIPTION
Fixes #125.

## Why

`pnpm dev` started, printed its banner, and served a blank page — every asset it owns returned 404:

```
$ curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1:61000/src/index.js  # 404
$ curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1:61000/ladle.css     # 404
```

```
[vite] Internal server error: Missing field `moduleType`
  Plugin: builtin:vite-react-refresh-wrapper
```

`vite.ladle.config.ts` imported `@vitejs/plugin-react`, which resolves to the root **6.0.5** — the version the Vite 8 library build needs. That config is merged into the Vite **6.4.3** instance Ladle 5.1.1 pins, and plugin-react 6 runs its react-refresh transform through a rolldown builtin whose result shape Vite 6 + Rollup rejects. Every module failed to transform, so nothing was served.

## What

Remove the `react()` plugin from `vite.ladle.config.ts`. Ladle injects its own `@vitejs/plugin-react` (4.7.0), pinned to the Vite major it runs, so the root plugin was redundant as well as harmful. The remaining options — `build.sourcemap`, `server.host`, `css.preprocessorOptions.scss` — are untouched, and a comment records why no react plugin belongs here.

Also adds `vite.ladle.config.ts` to the paths that trigger the `E2E` workflow: that config builds the stories the suite drives, so a change to it can break the suite without touching `src/` or `e2e/` — as this very branch does. Without it, this PR would have merged without the suite ever running.

## Verification

On this branch, rebased on a `main` that already contains #122 and #123:

| Check | Result |
| --- | --- |
| `pnpm dev` assets (`/`, `/src/index.js`, `/ladle.css`, `/meta.json`) | all **200**, zero transform errors |
| Stories render on the dev server | 5 tabs, active panel `Tab 1 content` |
| **react-refresh** — edit a story label while the page is open | change applied, **no full page reload** |
| e2e suite against the **dev server** (Chromium) | 18/18 |
| e2e suite via the build path (`CI=1`, 3 browsers) | **54/54** |
| `pnpm lint` | clean, no warnings |
| `pnpm test -- --run` | 68/68 |

The suite still targets the built stories: that stays the deterministic choice for CI. The difference is that `ladle serve` is now a usable fallback, and `pnpm dev` works for anyone opening the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)