### PR TITLE
fix(docs): inline the Astro tsconfig preset to stop the root-level noise

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,9 +1,30 @@
 {
-  "extends": "astro/tsconfigs/strict",
+  "$schema": "https://json.schemastore.org/tsconfig",
+  // Inlined from `astro/tsconfigs/strict` (astro 2.0.17), which this file used
+  // to `extends`. The docs site keeps its dependencies in docs/yarn.lock, so
+  // `astro` is not installed at the repo root — and every root-level Vite or
+  // Ladle command scans this file, fails to resolve the extends, and logs a
+  // stack trace. Inlining the options removes the cross-tree dependency.
+  // Re-check these against Astro's own preset when the site is migrated (#104).
   "compilerOptions": {
+    // astro/tsconfigs/base.json
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    // astro/tsconfigs/strict.json — minus `importsNotUsedAsValues`, which
+    // TypeScript 5 removed. Nothing type-checks this project, so the option
+    // only ever produced an editor diagnostic.
+    "strict": true,
+    // Options this file already set for itself
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "strictNullChecks": true,
-    "typeRoots": ["node_modules/@types", "types"],
+    "typeRoots": ["node_modules/@types", "types"]
   }
 }


### PR DESCRIPTION
Fixes #126.

## Why

`docs/tsconfig.json` extended `astro/tsconfigs/strict`. The docs site keeps its dependencies in `docs/yarn.lock`, so `astro` is never installed at the repo root — and the `vite-tsconfig-paths` plugin that Ladle bundles scans every `tsconfig.json` in the repo. It reached this one, failed to resolve the `extends`, and logged a ~25-line stack trace:

```
[tsconfig-paths] An error occurred while parsing ".../docs/tsconfig.json"
TSConfckParseError: failed to resolve "extends":"astro/tsconfigs/strict"
  cause: Error: Cannot find module 'astro/tsconfigs/strict/tsconfig.json'
```

In CI it appeared **three times per e2e run**, immediately before `54 passed`, which reads as a failing step to anyone scanning the log.

Note this is not an Astro version problem: whatever version the site pins, its packages stay in `docs/`, so the `extends` remains unresolvable from a root-level command. The Astro 5 migration (#104) would not have fixed it.

## What

Inline the preset's options into `docs/tsconfig.json`, removing the cross-tree dependency. The options are taken verbatim from the installed **astro 2.0.17** — `tsconfigs/base.json` + `tsconfigs/strict.json` — with one deliberate omission: `importsNotUsedAsValues`, which TypeScript 5 removed. Nothing type-checks this project, so that option only ever produced an editor diagnostic — and with the repo's TypeScript 5.9 it would now be an unknown-option error.

A comment records where the options came from and says to re-check them against Astro's own preset during #104.

## Verification

The `docs/node_modules` directory matters here: with the docs dependencies installed the `extends` resolves fine and the warning does not reproduce at all. So the before/after was measured **without** them, exactly as CI runs the root jobs:

| | occurrences of `tsconfig-paths` / `TSConfck` in `pnpm stories:build` |
| --- | --- |
| `main` | **3** |
| this branch | **0** |

And with the docs dependencies installed, as the `build-docs` job does:

| Check | Result |
| --- | --- |
| `cd docs && yarn build` | succeeds; `dist/` **byte-identical** to the pre-change build (12 files, `diff -r` clean) |
| `npx tsc -p docs/tsconfig.json --showConfig` | parses under TypeScript 5.9, no unknown options |
| `pnpm dev` log | reduced to the Ladle banner, nothing else |
| `pnpm lint` | clean |
| `pnpm test -- --run` | 68/68 |
| `CI=1 npx playwright test` | **54/54** (3 browsers) |

The `E2E` workflow is expected to skip on this PR: it touches nothing under `src/` or `e2e/`, which is the rule working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)