### PR TITLE
feat: build and publish src/styles.scss as dist/styles.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "ladle serve -h 127.0.0.1 --viteConfig vite.ladle.config.ts",
     "build:clean": "rimraf dist && pnpm run build",
+    "build:css": "sass src/styles.scss dist/styles.css --no-source-map",
     "build:dts": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:js": "tsc -p tsconfig.build.json && vite build",
-    "build": "pnpm run build:js && pnpm run build:dts",
+    "build": "pnpm run build:js && pnpm run build:dts && pnpm run build:css",
     "lint": "eslint .",
     "stories:build": "ladle build --viteConfig vite.ladle.config.ts",
     "stories:preview": "ladle preview -h 127.0.0.1 -p 61000",
@@ -30,6 +31,14 @@
   "main": "./dist/kevlar-tabs.es.js",
   "module": "./dist/kevlar-tabs.es.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/kevlar-tabs.es.js"
+    },
+    "./styles.css": "./dist/styles.css",
+    "./package.json": "./package.json"
+  },
   "packageManager": "pnpm@9.3.0",
   "devDependencies": {
     "@commitlint/cli": "^21.2.2",

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,13 @@ Some panels could not be defined for some reason. You can manually specify the i
 
 ## Styling
 
-You can use CSS classes that are set on the components:
+The components ship unstyled by default. A minimal stylesheet is published with the package and can be imported explicitly if you want a working look out of the box:
+
+```ts
+import 'kevlar-tabs/styles.css'
+```
+
+For anything custom, you can use CSS classes that are set on the components:
 
   - `Tabs` have no class (but you can create your own container).
   - `TabList` has the class `tablist`.


### PR DESCRIPTION
Closes #149

## Problem

The README documents the `tablist`, `tab`, `tab--active`, `tabpanel` classes, but `src/styles.scss` was neither built by `vite.config.ts` nor listed in the published package. A user following the README got unstyled tabs.

## Solution (option A from the issue)

Ship the stylesheet as an **opt-in** import, the standard way to distribute optional CSS in a library:

- New `build:css` script compiles `src/styles.scss` to `dist/styles.css` with the `sass` CLI (already a devDependency), chained into `build` so every release ships it.
- Added an `exports` map to `package.json` exposing `./styles.css` (plus the main entry with `types` first, and `./package.json`). The existing `main`/`module`/`types` fields are kept for older tooling.
- README's Styling section now starts by documenting the opt-in import:

  ```ts
  import 'kevlar-tabs/styles.css'
  ```

No `tabpanel` rules are needed in the stylesheet: inactive panels hide themselves with an inline `display: none`.

## Verification

- `pnpm run build:clean` produces `dist/styles.css`.
- `npm pack --dry-run` lists `dist/styles.css` (508 B) in the tarball.
- Installed the packed tarball in a temp project: `import.meta.resolve('kevlar-tabs/styles.css')` and the main entry both resolve, and the four components still import.
- `pnpm lint` and `pnpm test -- --run` (68 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)