### PR TITLE
fix: fall back to the first non-disabled tab when `selected` is invalid

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -52,12 +52,10 @@ const Tabs = ({
     [id, tabNames],
   )
   const tabRefs = useRef<HTMLLIElement[]>([])
-  const currentFocusIndex = useRef(
-    (typeof selected === 'string' ? tabNames.indexOf(selected) : selected) ?? 0,
-  )
   const [{ index: currentIndex, name: currentName }, setSelected] = useState(
-    () => computeState(tabNames, selected),
+    () => computeState(tabProps, selected),
   )
+  const currentFocusIndex = useRef(currentIndex)
 
   // Compared as a string so that a children update producing an equal tab list
   // does not reset the selected tab.
@@ -69,7 +67,7 @@ const Tabs = ({
   // immediately, without committing the intermediate result or painting it.
   if (previous.selected !== selected || previous.tabNamesKey !== tabNamesKey) {
     setPrevious({ selected, tabNamesKey })
-    setSelected(computeState(tabNames, selected))
+    setSelected(computeState(tabProps, selected))
   }
 
   const handleSelect = useCallback(
@@ -208,22 +206,49 @@ const Tabs = ({
 }
 
 function computeState(
-  tabNames: (string | undefined)[],
+  tabProps: TabProps[],
   selected?: number | string,
 ): {
   index: number
   name?: string
 } {
   if (Number.isInteger(selected)) {
-    return { index: selected as number, name: tabNames[selected as number] }
+    const index = selected as number
+    if (index >= 0 && index < tabProps.length) {
+      return { index, name: tabProps[index].name }
+    }
+    return fallbackState(tabProps, `no tab exists at index ${index}`)
   }
   if (selected) {
-    return {
-      index: tabNames.indexOf(selected as string),
-      name: selected as string,
+    const index = tabProps.findIndex((tab) => tab.name === selected)
+    if (index !== -1) {
+      return { index, name: selected as string }
     }
+    return fallbackState(tabProps, `no tab is named "${selected}"`)
   }
-  return { index: 0, name: tabNames[0] }
+  return { index: 0, name: tabProps[0]?.name }
+}
+
+// The library ships without node's ambient types: `process.env.NODE_ENV` is
+// left in the bundle for the consumer's bundler to substitute and eliminate.
+declare const process: { env: { NODE_ENV?: string } }
+
+function fallbackState(tabProps: TabProps[], reason: string) {
+  const index = Math.max(
+    tabProps.findIndex((tab) => !tab.disabled),
+    0,
+  )
+
+  if (
+    typeof process !== 'undefined' &&
+    process.env.NODE_ENV !== 'production'
+  ) {
+    console.warn(
+      `kevlar-tabs: ${reason}; falling back to the first non-disabled tab`,
+    )
+  }
+
+  return { index, name: tabProps[index]?.name }
 }
 
 function getNextIndex(currentIndex: number, tabProps: TabProps[]) {

--- a/src/__tests__/Tabs.test.tsx
+++ b/src/__tests__/Tabs.test.tsx
@@ -8,6 +8,7 @@ import {
   displayComponentWithCustomClassNames,
   displayComponentWithDisabledTab,
   displayComponentWithExternals,
+  displayComponentWithFirstTabDisabled,
   displayComponentWithHiddenTab,
   displayComponentWithNamedTabs,
   displayComponentWithoutAnyTab,
@@ -165,14 +166,51 @@ describe('Tabs', () => {
     })
 
     describe('when the select index is out of bound', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>
+
       beforeEach(() => {
         cleanup()
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         displayComponent({ selected: 3 })
       })
 
-      it('should not select any tab', () => {
-        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+      afterEach(() => {
+        warnSpy.mockRestore()
+      })
+
+      it('should fall back to the first tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'true')
         expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
+      })
+
+      it('should display the first tab panel', () => {
+        expect(ui.tabPanel1Content.get()).toBeInTheDocument()
+      })
+
+      it('should emit a warning', () => {
+        expect(warnSpy).toHaveBeenCalledWith(
+          'kevlar-tabs: no tab exists at index 3; falling back to the first non-disabled tab'
+        )
+      })
+    })
+
+    describe('when the select index is out of bound and the first tab is disabled', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        cleanup()
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        displayComponentWithFirstTabDisabled({ selected: 3 })
+      })
+
+      afterEach(() => {
+        warnSpy.mockRestore()
+      })
+
+      it('should fall back to the first non-disabled tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'true')
         expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
       })
     })
@@ -225,15 +263,28 @@ describe('Tabs', () => {
     })
 
     describe('when the name does not exist', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>
+
       beforeEach(() => {
         cleanup()
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         displayComponentWithNamedTabs({ selected: 'tab4' })
       })
 
-      it('should not select any tab', () => {
-        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+      afterEach(() => {
+        warnSpy.mockRestore()
+      })
+
+      it('should fall back to the first tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'true')
         expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
         expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
+      })
+
+      it('should emit a warning', () => {
+        expect(warnSpy).toHaveBeenCalledWith(
+          'kevlar-tabs: no tab is named "tab4"; falling back to the first non-disabled tab'
+        )
       })
     })
   })

--- a/src/__tests__/suts.tsx
+++ b/src/__tests__/suts.tsx
@@ -127,6 +127,23 @@ export function displayComponentWithDisabledTab(
   )
 }
 
+export function displayComponentWithFirstTabDisabled(
+  props: Partial<TabsProps> = {}
+) {
+  return render(
+    <Tabs {...props}>
+      <TabList>
+        <Tab disabled>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab>Tab 3</Tab>
+      </TabList>
+      <TabPanel>Tab 1 content</TabPanel>
+      <TabPanel>Tab 2 content</TabPanel>
+      <TabPanel>Tab 3 content</TabPanel>
+    </Tabs>
+  )
+}
+
 export function displayComponentWithCustomClassNames() {
   return render(
     <Tabs


### PR DESCRIPTION
Fixes #145

## Problem

`computeState` returned `index: -1` for an unknown tab name, and an out-of-range numeric `selected` passed through unchecked. In both cases no tab was active, no panel rendered, and nothing was logged. The `currentFocusIndex` ref had the same unchecked `indexOf` and could start at `-1`.

## Fix

- `computeState` now takes `tabProps` (so it can see `disabled` flags), bound-checks numeric indices, and resolves names with `findIndex`.
- Both invalid cases fall back to the first non-disabled tab and emit a `console.warn` in development builds.
- The warning is guarded by `typeof process !== 'undefined' && process.env.NODE_ENV !== 'production'`, so consumers' bundlers strip it from production builds while the module still loads in browsers without a bundler (where `process` is undefined). A module-local `declare const process` keeps the browser-targeted build compiling without node's ambient types; verified the expression is left intact in `dist/kevlar-tabs.es.js` for downstream substitution.
- `currentFocusIndex` now initialises from the computed state instead of a raw `indexOf`.

## Tests

- Updated the two tests that pinned the old silent behaviour ("should not select any tab") to assert the fallback selection, the rendered panel, and the exact warning message.
- Added a case falling back past a disabled first tab, with a new `displayComponentWithFirstTabDisabled` fixture.
- 72/72 tests pass; `tsc -p tsconfig.build.json` and eslint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)