### PR TITLE
fix: remove tabIndex from the tablist so it is not a tab stop

### DIFF
--- a/e2e/keyboard-navigation.spec.ts
+++ b/e2e/keyboard-navigation.spec.ts
@@ -57,6 +57,24 @@ test.describe('Keyboard navigation with auto activation', () => {
       '-1',
     )
   })
+
+})
+
+test.describe('Tab stops', () => {
+  test('a single Tab press moves focus onto the active tab', async ({
+    page,
+  }) => {
+    await gotoStory(page, 'tabs--default')
+
+    // The tablist itself must not be a tab stop.
+    await expect(page.getByRole('tablist')).not.toHaveAttribute('tabindex')
+
+    // From a fresh page, the first Tab press must land on the active tab,
+    // not on the tablist container.
+    await page.keyboard.press('Tab')
+
+    await expect(page.getByRole('tab', { name: 'Tab 1' })).toBeFocused()
+  })
 })
 
 test.describe('Keyboard navigation without auto activation', () => {

--- a/src/TabList.tsx
+++ b/src/TabList.tsx
@@ -33,7 +33,6 @@ const TabList: FunctionComponent<TabListProps> = ({
     <ul
       role="tablist"
       className={className || 'tablist'}
-      tabIndex={0}
       {...ulProps}
       onKeyDown={handleKeyDown}
     >

--- a/src/__tests__/TabList.test.tsx
+++ b/src/__tests__/TabList.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { byRole } from 'testing-library-selector'
 import TabList from '../TabList'
 
@@ -20,9 +19,7 @@ describe('Tab', () => {
     expect(ui.tabList.get()).toBeInTheDocument()
   })
 
-  it('can take the focus', async () => {
-    await userEvent.click(ui.tabList.get())
-
-    expect(ui.tabList.get()).toHaveFocus()
+  it('is not in the tab sequence', () => {
+    expect(ui.tabList.get()).not.toHaveAttribute('tabindex')
   })
 })


### PR DESCRIPTION
Closes #138

## Problem

`TabList.tsx` set `tabIndex={0}` on the `<ul role="tablist">`, making the container itself focusable. The WAI-ARIA Tabs pattern relies on a roving tabindex: only the active tab belongs to the tab sequence, never the `tablist` container. Keyboard users had to cross two tab stops for a single component, and the first one (the `<ul>`) gave no visible focus indicator.

## Fix

- Removed `tabIndex={0}` from the `<ul>` in `TabList.tsx`. The `onKeyDown` handler keeps working through bubbling from the focused tab, which already carries `tabIndex={active ? 0 : -1}`.
- Updated the `TabList` unit test: replaced the "can take the focus" test (which asserted the broken behavior) with an assertion that the tablist carries no `tabindex`.
- Added an e2e test in `keyboard-navigation.spec.ts` asserting that a single `Tab` press from a fresh page lands directly on the active tab, and that the tablist has no `tabindex` attribute. Verified the test fails against the previous implementation.

## Tests

- 72 unit tests pass
- 57 e2e tests pass (chromium, firefox, webkit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)