### PR TITLE
fix: make TabPanel keyboard-focusable with a default tabIndex of 0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,14 @@ Some panels could not be defined for some reason. You can manually specify the i
 <TabPanel index={2}>Tab 3 content</TabPanel>
 ```
 
+Panels are keyboard-focusable by default (`tabIndex={0}`), as [the APG recommends](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) when a panel contains no focusable element. If your panel content starts with a focusable element, you can opt out:
+
+```tsx
+<TabPanel tabIndex={-1}>
+  <input placeholder="Already focusable" />
+</TabPanel>
+```
+
 ## Tabs properties
 
 | Property | Type | Description |

--- a/src/TabPanel.tsx
+++ b/src/TabPanel.tsx
@@ -12,6 +12,9 @@ export type TabPanelProps = {
   disabled?: boolean
   // Only used in the Tabs component to override the index of the tab panel.
   index?: number
+  // The APG requires the panel itself to be focusable when it contains no
+  // focusable element; pass a different value (e.g. -1) to opt out.
+  tabIndex?: number
 } & HTMLAttributes<HTMLDivElement>
 
 const TabPanel: FunctionComponent<TabPanelProps> = ({
@@ -21,6 +24,7 @@ const TabPanel: FunctionComponent<TabPanelProps> = ({
   classNameActive,
   classNameDisabled,
   disabled,
+  tabIndex = 0,
   ...divProps
 }) => {
   // State rather than a ref: this value is read during render to decide
@@ -41,6 +45,7 @@ const TabPanel: FunctionComponent<TabPanelProps> = ({
         [classNameDisabled || 'tabpanel--disabled']: disabled,
       })}
       style={!active ? { display: 'none' } : undefined}
+      tabIndex={tabIndex}
       {...divProps}
     >
       {(active || hasBeenActive) && children}

--- a/src/__tests__/TabPanel.test.tsx
+++ b/src/__tests__/TabPanel.test.tsx
@@ -2,20 +2,27 @@ import { render } from '@testing-library/react'
 import { byRole } from 'testing-library-selector'
 import TabPanel from '../TabPanel'
 
-function createTab() {
-  render(<TabPanel active>Test</TabPanel>)
-}
-
 const ui = {
   tabpanel: byRole('tabpanel'),
 }
 
 describe('TabPanel', () => {
-  beforeEach(() => {
-    createTab()
+  it('should render the component with the right role', () => {
+    render(<TabPanel active>Test</TabPanel>)
+    expect(ui.tabpanel.get()).toBeInTheDocument()
   })
 
-  it('should render the component with the right role', () => {
-    expect(ui.tabpanel.get()).toBeInTheDocument()
+  it('should be focusable by default', () => {
+    render(<TabPanel active>Test</TabPanel>)
+    expect(ui.tabpanel.get()).toHaveAttribute('tabindex', '0')
+  })
+
+  it('should allow overriding tabIndex', () => {
+    render(
+      <TabPanel active tabIndex={-1}>
+        Test
+      </TabPanel>,
+    )
+    expect(ui.tabpanel.get()).toHaveAttribute('tabindex', '-1')
   })
 })


### PR DESCRIPTION
## Summary

`TabPanel` never set `tabIndex`, so once keyboard focus left the tab list, the panel content was unreachable by keyboard. The [APG tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) requires the panel to receive `tabIndex={0}` when it contains no focusable element.

## Changes

- `TabPanel` now renders `tabIndex={0}` by default, exposed as a prop so consumers can opt out (e.g. `tabIndex={-1}` when the panel content is already focusable). An explicit value always wins, including through the `cloneElement` in `Tabs`.
- Added tests for the default value and the override.
- Documented the behavior in the README.

## Why not automatic detection of focusable descendants?

Selector-based detection is inherently best-effort: it can match elements that aren't actually focusable (hidden, inside `inert`/disabled `fieldset`/closed `details`), in which case the panel would drop its tab stop while nothing inside is reachable — recreating exactly this bug. Checking real focusability requires per-candidate style computation, and shadow DOM is invisible to `querySelector`. Meanwhile the cost of a redundant `tabindex="0"` is a single extra Tab press, and the APG examples themselves ship a static `tabindex="0"`. The static default plus an explicit opt-out is the safer trade-off.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)