### PR TITLE
fix: handle Home and End keys in the tab list

### DIFF
--- a/src/TabList.tsx
+++ b/src/TabList.tsx
@@ -7,6 +7,8 @@ export type TabListProps = {
   children?: React.ReactNode
   onArrowLeftKeyDown?: () => void
   onArrowRightKeyDown?: () => void
+  onHomeKeyDown?: () => void
+  onEndKeyDown?: () => void
 } & HTMLAttributes<HTMLUListElement>
 
 const TabList: FunctionComponent<TabListProps> = ({
@@ -14,6 +16,8 @@ const TabList: FunctionComponent<TabListProps> = ({
   className,
   onArrowLeftKeyDown,
   onArrowRightKeyDown,
+  onHomeKeyDown,
+  onEndKeyDown,
   ...ulProps
 }: TabListProps & HTMLAttributes<HTMLUListElement>) => {
   const handleKeyDown = useCallback(
@@ -24,9 +28,15 @@ const TabList: FunctionComponent<TabListProps> = ({
       } else if (event.key === 'ArrowRight') {
         onArrowRightKeyDown?.()
         event.preventDefault()
+      } else if (event.key === 'Home') {
+        onHomeKeyDown?.()
+        event.preventDefault()
+      } else if (event.key === 'End') {
+        onEndKeyDown?.()
+        event.preventDefault()
       }
     },
-    [onArrowLeftKeyDown, onArrowRightKeyDown]
+    [onArrowLeftKeyDown, onArrowRightKeyDown, onHomeKeyDown, onEndKeyDown]
   )
 
   return (

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -117,6 +117,38 @@ const Tabs = ({
     }
   }, [autoActivate, handleSelect, tabNames, tabProps])
 
+  const selectFirst = useCallback(() => {
+    if (tabProps.every((tab) => tab.disabled)) {
+      return
+    }
+
+    const firstIndex = getFirstIndex(tabProps)
+    const firstName = tabNames[firstIndex]
+
+    if (autoActivate) {
+      handleSelect(firstIndex, firstName)
+    } else {
+      currentFocusIndex.current = firstIndex
+      tabRefs.current[firstIndex].focus()
+    }
+  }, [autoActivate, handleSelect, tabNames, tabProps])
+
+  const selectLast = useCallback(() => {
+    if (tabProps.every((tab) => tab.disabled)) {
+      return
+    }
+
+    const lastIndex = getLastIndex(tabProps)
+    const lastName = tabNames[lastIndex]
+
+    if (autoActivate) {
+      handleSelect(lastIndex, lastName)
+    } else {
+      currentFocusIndex.current = lastIndex
+      tabRefs.current[lastIndex].focus()
+    }
+  }, [autoActivate, handleSelect, tabNames, tabProps])
+
   const getChildren = useCallback(() => {
     let tabPanelIndex = 0
 
@@ -156,6 +188,8 @@ const Tabs = ({
           className: classNames?.tabList,
           onArrowLeftKeyDown: selectPrevious,
           onArrowRightKeyDown: selectNext,
+          onHomeKeyDown: selectFirst,
+          onEndKeyDown: selectLast,
         })
       }
 
@@ -198,6 +232,8 @@ const Tabs = ({
     currentIndex,
     focusOnInit,
     handleSelect,
+    selectFirst,
+    selectLast,
     selectNext,
     selectPrevious,
     tabIds,
@@ -269,6 +305,24 @@ function getPreviousIndex(currentIndex: number, tabProps: TabProps[]) {
   }
 
   return previousIndex
+}
+
+function getFirstIndex(tabProps: TabProps[]) {
+  let firstIndex = 0
+  while (tabProps[firstIndex].disabled) {
+    firstIndex += 1
+  }
+
+  return firstIndex
+}
+
+function getLastIndex(tabProps: TabProps[]) {
+  let lastIndex = tabProps.length - 1
+  while (tabProps[lastIndex].disabled) {
+    lastIndex -= 1
+  }
+
+  return lastIndex
 }
 
 export default Tabs

--- a/src/__tests__/Tabs.test.tsx
+++ b/src/__tests__/Tabs.test.tsx
@@ -10,6 +10,7 @@ import {
   displayComponentWithExternals,
   displayComponentWithFirstTabDisabled,
   displayComponentWithHiddenTab,
+  displayComponentWithLastTabDisabled,
   displayComponentWithNamedTabs,
   displayComponentWithoutAnyTab,
   displayComponentWithSparses,
@@ -432,10 +433,106 @@ describe('Tabs', () => {
       })
     })
 
+    describe('when hitting the end key', () => {
+      beforeEach(async () => {
+        await userEvent.type(ui.tab1.get(), '{end}')
+      })
+
+      it('should select the last tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'true')
+      })
+
+      it('should give the focus to the last tab', () => {
+        expect(ui.tab3.get()).toHaveFocus()
+      })
+    })
+
+    describe('when the selected tab is the last one and hitting the home key', () => {
+      beforeEach(async () => {
+        cleanup()
+        displayComponent({ focusOnInit: true, selected: 2 })
+        await userEvent.type(ui.tab3.get(), '{home}')
+      })
+
+      it('should select the first tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'true')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
+      })
+
+      it('should give the focus to the first tab', () => {
+        expect(ui.tab1.get()).toHaveFocus()
+      })
+    })
+
+    describe('when the first tab is disabled and hitting the home key', () => {
+      beforeEach(async () => {
+        cleanup()
+        displayComponentWithFirstTabDisabled({ selected: 2 })
+        await userEvent.type(ui.tab3.get(), '{home}')
+      })
+
+      it('should select the first non-disabled tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'true')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
+      })
+    })
+
+    describe('when the last tab is disabled and hitting the end key', () => {
+      beforeEach(async () => {
+        cleanup()
+        displayComponentWithLastTabDisabled()
+        await userEvent.type(ui.tab1.get(), '{end}')
+      })
+
+      it('should select the last non-disabled tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'true')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
+      })
+    })
+
     describe('when autoActivate is false', () => {
       beforeEach(() => {
         cleanup()
         displayComponent({ autoActivate: false })
+      })
+
+      describe('when hitting the end key', () => {
+        beforeEach(async () => {
+          await userEvent.type(ui.tab1.get(), '{end}')
+        })
+
+        it('should not change the selected tab', () => {
+          expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'true')
+          expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+          expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
+        })
+
+        it('should give the focus to the last tab', () => {
+          expect(ui.tab3.get()).toHaveFocus()
+        })
+      })
+
+      describe('when hitting the home key from the last tab', () => {
+        beforeEach(async () => {
+          cleanup()
+          displayComponent({ selected: 2, autoActivate: false })
+          await userEvent.type(ui.tab3.get(), '{home}')
+        })
+
+        it('should not change the selected tab', () => {
+          expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+          expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+          expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'true')
+        })
+
+        it('should give the focus to the first tab', () => {
+          expect(ui.tab1.get()).toHaveFocus()
+        })
       })
 
       describe('when hitting the left arrow', () => {

--- a/src/__tests__/suts.tsx
+++ b/src/__tests__/suts.tsx
@@ -144,6 +144,23 @@ export function displayComponentWithFirstTabDisabled(
   )
 }
 
+export function displayComponentWithLastTabDisabled(
+  props: Partial<TabsProps> = {}
+) {
+  return render(
+    <Tabs {...props}>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab disabled>Tab 3</Tab>
+      </TabList>
+      <TabPanel>Tab 1 content</TabPanel>
+      <TabPanel>Tab 2 content</TabPanel>
+      <TabPanel>Tab 3 content</TabPanel>
+    </Tabs>
+  )
+}
+
 export function displayComponentWithCustomClassNames() {
   return render(
     <Tabs


### PR DESCRIPTION
Closes #139

`TabList.handleKeyDown` only handled `ArrowLeft` and `ArrowRight`. The WAI-ARIA Tabs pattern also requires `Home` (first activatable tab) and `End` (last activatable tab).

## Changes

- `TabList` gains `onHomeKeyDown` / `onEndKeyDown` props and handles the `Home` and `End` keys (with `preventDefault`, like the arrows).
- `Tabs` wires them to new `selectFirst` / `selectLast` callbacks, backed by `getFirstIndex` / `getLastIndex` helpers that skip `disabled` tabs, mirroring `getNextIndex` / `getPreviousIndex`.
- Both keys respect `autoActivate`: when it is `false`, they only move focus, as the arrows do.

## Tests

- `End` selects/focuses the last tab; `Home` selects/focuses the first tab.
- Disabled edge tabs are skipped (`Home` with first tab disabled, `End` with last tab disabled — new `displayComponentWithLastTabDisabled` SUT).
- `autoActivate: false`: `Home`/`End` move focus without changing the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)