### PR TITLE
fix: activate tabs with Enter and Space in autoActivate mode

### DIFF
--- a/e2e/keyboard-navigation.spec.ts
+++ b/e2e/keyboard-navigation.spec.ts
@@ -46,6 +46,28 @@ test.describe('Keyboard navigation with auto activation', () => {
     await expect(page.getByText('Selected index: 0')).toBeVisible()
   })
 
+  test('Enter activates the focused tab', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Tab 4' }).focus()
+    await page.keyboard.press('Enter')
+
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 3')).toBeVisible()
+  })
+
+  test('Space activates the focused tab', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Tab 5' }).focus()
+    await page.keyboard.press(' ')
+
+    await expect(page.getByRole('tab', { name: 'Tab 5' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByText('Selected index: 4')).toBeVisible()
+  })
+
   test('only the selected tab is reachable with Tab', async ({ page }) => {
     // Roving tabindex: the selected tab holds tabindex=0, the others -1.
     await expect(page.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(

--- a/src/Tab.tsx
+++ b/src/Tab.tsx
@@ -25,6 +25,7 @@ const Tab: ForwardRefRenderFunction<HTMLLIElement, TabProps> = (
     classNameDisabled,
     disabled,
     onClick,
+    onKeyDown,
     ...liProps
   },
   ref,
@@ -61,6 +62,7 @@ const Tab: ForwardRefRenderFunction<HTMLLIElement, TabProps> = (
       aria-disabled={disabled}
       {...liProps}
       onClick={disabled ? undefined : onClick}
+      onKeyDown={disabled ? undefined : onKeyDown}
     >
       {children}
     </li>

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -137,13 +137,13 @@ const Tabs = ({
                   'aria-controls': `${tabIds[index]}-panel`,
                   id: `${tabIds[index]}-tab`,
                   onClick: () => handleSelect(index, tab.props.name),
-                  onKeyDown: autoActivate
-                    ? undefined
-                    : (event: React.KeyboardEvent) => {
-                        if (event.key === 'Enter' || event.key === ' ') {
-                          handleSelect(index, tab.props.name)
-                        }
-                      },
+                  onKeyDown: (event: React.KeyboardEvent) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      // Prevent Space from scrolling the page.
+                      event.preventDefault()
+                      handleSelect(index, tab.props.name)
+                    }
+                  },
                   ref: (elt: HTMLLIElement) => {
                     tabRefs.current[index] = elt
                   },
@@ -186,7 +186,6 @@ const Tabs = ({
       return child
     })
   }, [
-    autoActivate,
     children,
     classNames?.tab,
     classNames?.tabActive,

--- a/src/__tests__/Tabs.test.tsx
+++ b/src/__tests__/Tabs.test.tsx
@@ -393,6 +393,47 @@ describe('Tabs', () => {
       })
     })
 
+    describe('when hitting enter on a focused unselected tab', () => {
+      beforeEach(async () => {
+        act(() => ui.tab3.get().focus())
+        await userEvent.keyboard('{Enter}')
+      })
+
+      it('should select the focused tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'true')
+      })
+    })
+
+    describe('when hitting space on a focused unselected tab', () => {
+      beforeEach(async () => {
+        act(() => ui.tab3.get().focus())
+        await userEvent.keyboard(' ')
+      })
+
+      it('should select the focused tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'true')
+      })
+    })
+
+    describe('when hitting enter on a focused disabled tab', () => {
+      beforeEach(async () => {
+        cleanup()
+        displayComponentWithDisabledTab()
+        act(() => ui.tab2.get().focus())
+        await userEvent.keyboard('{Enter}')
+      })
+
+      it('should not select the disabled tab', () => {
+        expect(ui.tab1.get()).toHaveAttribute('aria-selected', 'true')
+        expect(ui.tab2.get()).toHaveAttribute('aria-selected', 'false')
+        expect(ui.tab3.get()).toHaveAttribute('aria-selected', 'false')
+      })
+    })
+
     describe('when the selected tab is the last one', () => {
       beforeEach(() => {
         cleanup()


### PR DESCRIPTION
## Summary

Fixes #140.

In `Tabs.tsx`, the Enter/Space keydown handler was only wired when `autoActivate === false`. Since `Tab` renders an `<li>` — which has no native keyboard activation — a focused tab could not be activated from the keyboard in automatic mode (the default).

Rather than changing the rendered markup (the `<button role="tab">` rework flagged as breaking in the issue), this keeps the `<li role="tab">` markup and fixes the behavior:

- **`src/Tabs.tsx`** — the Enter/Space `onKeyDown` handler is now always attached, regardless of `autoActivate`. It also calls `event.preventDefault()` so Space no longer scrolls the page (a pre-existing gap in manual mode too).
- **`src/Tab.tsx`** — `onKeyDown` is stripped on disabled tabs, mirroring the existing `onClick` guard. A disabled `<li>` with `tabindex="-1"` can still receive focus from a click, and without this guard Enter would have selected it.

Note: with the handler wired, `li[role="tab"]` passes `eslint-plugin-jsx-a11y` default config (`li` → `tab` is an allowed role promotion). The remaining points from #140 (forced-colors rendering, native `:disabled`) are inherent to non-button markup and left for a possible v2.

## Tests

- Unit: 3 new cases — Enter and Space activate a focused unselected tab in auto mode; Enter on a focused disabled tab does nothing (75/75 pass).
- E2E: 2 new Playwright cases in the auto-activation suite (63/63 pass on chromium/firefox/webkit).
- Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)