### PR TITLE
fix: declare sideEffects to enable tree-shaking, keeping CSS exempt

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   ],
   "license": "MIT",
   "repository": "neolitec/kevlar-tabs",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "main": "./dist/kevlar-tabs.es.js",
   "module": "./dist/kevlar-tabs.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Adds the `sideEffects` field to `package.json` so consumer bundlers (webpack, Rollup, etc.) can aggressively drop unused code from the library.

Since the package publishes `dist/styles.css` (see #12), a plain `false` would let bundlers prune the stylesheet import. The field is therefore declared as an array exempting CSS files:

```json
"sideEffects": ["**/*.css"]
```

All JS modules remain declared side-effect-free, which is safe since all four components are pure.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)