### PR TITLE
refactor: drop the classnames dependency (zero runtime dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@types/rollup-plugin-peer-deps-external": "^2.2.5",
     "@typescript-eslint/parser": "^8.8.0",
     "@vitejs/plugin-react": "^6.0.5",
-    "classnames": "^2.5.1",
     "eslint": "^10.8.1",
     "eslint-plugin-jsx-a11y-x": "^0.2.0",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -88,8 +87,5 @@
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-  },
-  "dependencies": {
-    "classnames": "^2.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      classnames:
-        specifier: ^2.0.0
-        version: 2.5.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.2.2

--- a/src/Tab.tsx
+++ b/src/Tab.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import classNames from 'classnames'
 import type { ForwardRefRenderFunction, HTMLAttributes } from 'react'
 import React, { forwardRef, useEffect, useRef } from 'react'
+import { classNames } from './helpers/classNames'
 
 export type TabProps = {
   active?: boolean
@@ -50,13 +50,10 @@ const Tab: ForwardRefRenderFunction<HTMLLIElement, TabProps> = (
         }
       }}
       role="tab"
-      className={classNames([
-        className || 'tab',
-        {
-          [classNameActive || 'tab--active']: active,
-          [classNameDisabled || 'tab--disabled']: disabled,
-        },
-      ])}
+      className={classNames(className || 'tab', {
+        [classNameActive || 'tab--active']: active,
+        [classNameDisabled || 'tab--disabled']: disabled,
+      })}
       tabIndex={active ? 0 : -1}
       aria-selected={active}
       aria-disabled={disabled}

--- a/src/TabPanel.tsx
+++ b/src/TabPanel.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import classNames from 'classnames'
 import type { FunctionComponent, HTMLAttributes } from 'react'
 import React, { useState } from 'react'
+import { classNames } from './helpers/classNames'
 
 export type TabPanelProps = {
   active?: boolean

--- a/src/__tests__/classNames.test.ts
+++ b/src/__tests__/classNames.test.ts
@@ -1,0 +1,25 @@
+import { classNames } from '../helpers/classNames'
+
+describe('classNames', () => {
+  it('should join string arguments with a space', () => {
+    expect(classNames('tab', 'custom')).toBe('tab custom')
+  })
+
+  it('should ignore null, undefined and empty strings', () => {
+    expect(classNames('tab', null, undefined, '')).toBe('tab')
+  })
+
+  it('should include object keys whose value is truthy', () => {
+    expect(
+      classNames('tab', {
+        'tab--active': true,
+        'tab--disabled': false,
+        'tab--hidden': undefined,
+      })
+    ).toBe('tab tab--active')
+  })
+
+  it('should return an empty string when nothing applies', () => {
+    expect(classNames(undefined, { 'tab--active': false })).toBe('')
+  })
+})

--- a/src/helpers/classNames.ts
+++ b/src/helpers/classNames.ts
@@ -1,0 +1,16 @@
+type ClassValue = string | null | undefined | Record<string, boolean | undefined>
+
+export function classNames(...values: ClassValue[]): string {
+  const classes: string[] = []
+  for (const value of values) {
+    if (!value) {
+      continue
+    }
+    if (typeof value === 'string') {
+      classes.push(value)
+    } else {
+      classes.push(...Object.keys(value).filter((key) => value[key]))
+    }
+  }
+  return classes.join(' ')
+}


### PR DESCRIPTION
## Summary

Closes #150

`classnames` was the library's only runtime dependency, used trivially in `Tab.tsx` and `TabPanel.tsx`. This PR replaces it with a small internal helper (`src/helpers/classNames.ts`) that covers the exact usage: string arguments plus conditional class objects.

- Removed `classnames` from both `dependencies` and `devDependencies` — the package now has **zero runtime dependencies**.
- Since the Vite build only externalizes React, `classnames` was previously inlined into the bundle; the helper is smaller than the inlined library code.
- Added unit tests for the helper.

## Test plan

- [x] `pnpm vitest run` — 91 tests pass (including 4 new helper tests)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — full build (js, dts, css, use-client verification) passes
- [x] Verified `dist/kevlar-tabs.es.js` no longer contains any `classnames` code

🤖 Generated with [Claude Code](https://claude.com/claude-code)