### PR TITLE
test: add axe-core accessibility checks to the Playwright suite

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,50 @@
+import { AxeBuilder } from '@axe-core/playwright'
+import { expect, test, type Page } from '@playwright/test'
+import { gotoStory, STORY_IDS } from './fixtures/story'
+
+// Ladle's preview page is a bare story harness, not a full document: it has
+// no landmark regions, so the page-level "region" rule would flag every
+// story for reasons unrelated to the components under test.
+async function scanStory(page: Page) {
+  return new AxeBuilder({ page }).disableRules(['region']).analyze()
+}
+
+test.describe('Accessibility (axe-core)', () => {
+  for (const story of STORY_IDS) {
+    test(`${story} has no violations in its initial state`, async ({
+      page,
+    }) => {
+      await gotoStory(page, story)
+
+      const { violations } = await scanStory(page)
+
+      expect(violations).toEqual([])
+    })
+  }
+
+  test('tabs--default has no violations after keyboard navigation', async ({
+    page,
+  }) => {
+    await gotoStory(page, 'tabs--default')
+    await page.getByRole('tab', { name: 'Tab 1' }).focus()
+    await page.keyboard.press('ArrowRight')
+    await expect(page.getByRole('tabpanel')).toHaveText('Tab 4 content')
+
+    const { violations } = await scanStory(page)
+
+    expect(violations).toEqual([])
+  })
+
+  test('tabs--auto-activation-disabled has no violations while focus and selection differ', async ({
+    page,
+  }) => {
+    await gotoStory(page, 'tabs--auto-activation-disabled')
+    await page.getByRole('tab', { name: 'Tab 1' }).focus()
+    await page.keyboard.press('ArrowRight')
+    await expect(page.getByRole('tab', { name: 'Tab 4' })).toBeFocused()
+
+    const { violations } = await scanStory(page)
+
+    expect(violations).toEqual([])
+  })
+})

--- a/e2e/fixtures/story.ts
+++ b/e2e/fixtures/story.ts
@@ -1,13 +1,16 @@
 import { expect, type Page } from '@playwright/test'
 
 /** Ladle story ids, as exposed by http://127.0.0.1:61000/meta.json */
-export type StoryId =
-  | 'tabs--default'
-  | 'tabs--lazy-loading'
-  | 'tabs--styled-components'
-  | 'tabs--auto-activation-disabled'
-  | 'tabs--hidden-tab'
-  | 'tabs--empty-tabs'
+export const STORY_IDS = [
+  'tabs--default',
+  'tabs--lazy-loading',
+  'tabs--styled-components',
+  'tabs--auto-activation-disabled',
+  'tabs--hidden-tab',
+  'tabs--empty-tabs',
+] as const
+
+export type StoryId = (typeof STORY_IDS)[number]
 
 /**
  * Opens a story in Ladle's preview mode (no sidebar, no addon toolbar), so the

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   ],
   "packageManager": "pnpm@9.3.0",
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
     "@eslint-react/eslint-plugin": "^5.18.6",
@@ -62,6 +63,7 @@
     "@types/react-dom": "^19.2.4",
     "@types/rollup-plugin-peer-deps-external": "^2.2.5",
     "@typescript-eslint/parser": "^8.8.0",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "@vitejs/plugin-react": "^6.0.5",
     "classnames": "^2.5.1",
     "eslint": "^10.8.1",
@@ -78,7 +80,6 @@
     "sass": "^1.79.4",
     "styled-components": "^6.1.13",
     "testing-library-selector": "^0.3.1",
-    "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.0.1",
     "vite": "^8.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^2.0.0
         version: 2.5.1
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.13.0
+        version: 4.13.0(playwright-core@1.62.1)
       '@commitlint/cli':
         specifier: ^21.2.2
         version: 21.2.2(@types/node@26.2.0)(@typescript/typescript6@6.0.2)(conventional-commits-parser@7.1.2)
@@ -119,6 +122,11 @@ importers:
         version: 0.1.1(vitest@4.1.10(@types/node@26.2.0)(happy-dom@20.11.2)(msw@2.15.0(@types/node@26.2.0)(@typescript/typescript6@6.0.2))(vite@8.2.1(@types/node@26.2.0)(jiti@2.6.1)(sass@1.102.0)))
 
 packages:
+
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -3527,6 +3535,11 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@axe-core/playwright@4.13.0(playwright-core@1.62.1)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.62.1
 
   '@babel/code-frame@7.29.7':
     dependencies:

--- a/src/__stories__/Tabs.stories.tsx
+++ b/src/__stories__/Tabs.stories.tsx
@@ -73,8 +73,12 @@ export const Default = () => {
               {tab}
             </Tab>
           ))}
-          <button type="button">Action</button>
         </TabList>
+        {/* A tablist may only contain tabs (axe: aria-required-children),
+            so external actions live next to it, not inside. The "Tabs
+            tolerate non-Tab children" behavior stays covered by the unit
+            test displayComponentWithExternals. */}
+        <button type="button">Action</button>
         {tabs.map((tab) => (
           <TabPanel key={tab}>{tab} content</TabPanel>
         ))}
@@ -132,8 +136,8 @@ export const StyledComponents = () => {
               {tab}
             </CustomTab>
           ))}
-          <button type="button">Action</button>
         </TabList>
+        <button type="button">Action</button>
         {tabs.map((tab) => (
           <CustomTabPanel key={tab}>{tab} content</CustomTabPanel>
         ))}
@@ -165,8 +169,8 @@ export const AutoActivationDisabled = () => {
               {tab}
             </Tab>
           ))}
-          <button type="button">Action</button>
         </TabList>
+        <button type="button">Action</button>
         {tabs.map((tab) => (
           <TabPanel key={tab}>{tab} content</TabPanel>
         ))}


### PR DESCRIPTION
## Summary

Closes #160.

- Adds `@axe-core/playwright` as a devDependency and a new `e2e/accessibility.spec.ts` that scans **every Ladle story** for WAI-ARIA violations in its initial state, on all three browser projects (Chromium, Firefox, WebKit).
- Adds two stateful scans on top of the initial-state sweep: `tabs--default` after keyboard navigation, and `tabs--auto-activation-disabled` while focus and selection point at different tabs.
- Only the page-level `region` rule is disabled — Ladle's bare preview harness has no landmark regions, so it would flag every story for reasons unrelated to the components. Everything component-related runs at full strength.
- `e2e/fixtures/story.ts` now derives the `StoryId` union from a runtime `STORY_IDS` array so the a11y spec can iterate over all stories, and new stories are picked up by adding one entry.

## The suite already caught something

The very first run flagged a **critical `aria-required-children` violation** in three stories: a raw `<button>Action</button>` sat directly inside the `role="tablist"` element, and a tablist may only contain tabs. The button now lives next to the TabList instead. The "Tabs tolerate non-Tab children" behavior remains covered by the `displayComponentWithExternals` unit test.

This is exactly the class of issue that #1 and #4 were — the suite now guards against regressions of that kind.

## Test plan

- [x] `pnpm exec playwright test` — 87 tests pass on Chromium, Firefox and WebKit (8 new a11y tests × 3 browsers)
- [x] `pnpm exec vitest run` — 87 unit tests pass
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)